### PR TITLE
récupération token test swagger dev only

### DIFF
--- a/laundrymap-back/.env
+++ b/laundrymap-back/.env
@@ -70,3 +70,12 @@ GOOGLE_AUTH_CONFIG=%kernel.project_dir%/path/to/file.json
 ###> fichiers publics frontend ###
 FRONTEND_PUBLIC_DIR=/frontend-public
 ###< fichiers publics frontend ###
+
+###> signalement anti-abus ###
+# Nombre de signalements avant masquage automatique du commentaire (RG-209)
+SIGNALEMENT_SEUIL_MASQUAGE=5
+# Nombre max de signalements qu'un utilisateur peut envoyer sur la période (RG-210)
+SIGNALEMENT_LIMITE_UTILISATEUR=10
+# Durée de la période en heures pour le rate limiting (RG-210)
+SIGNALEMENT_PERIODE_HEURES=24
+###< signalement anti-abus ###

--- a/laundrymap-back/config/packages/lexik_jwt_authentication.yaml
+++ b/laundrymap-back/config/packages/lexik_jwt_authentication.yaml
@@ -8,7 +8,7 @@ lexik_jwt_authentication:
             enabled: true
             name: BEARER
         authorization_header:
-            enabled: false
+            enabled: true
     set_cookies:
         BEARER:
             lifetime: 3600

--- a/laundrymap-back/config/packages/nelmio_api_doc.yaml
+++ b/laundrymap-back/config/packages/nelmio_api_doc.yaml
@@ -36,40 +36,19 @@ nelmio_api_doc:
         security:
             - BearerAuth: []
 
-        # Déclaration manuelle des endpoints json_login (non détectés automatiquement)
         paths:
+            # Surcharge security : cadenas ouvert sur toutes les routes login
             /api/v1/admin/login_check:
                 post:
-                    tags:
-                        - Authentification Admin
-                    summary: Connexion administrateur
-                    security: []  
-                    requestBody:
-                        required: true
-                        content:
-                            application/json:
-                                schema:
-                                    type: object
-                                    required: [email, password]
-                                    properties:
-                                        email:
-                                            type: string
-                                            example: admin@example.com
-                                        password:
-                                            type: string
-                                            example: Admin1234.
-                    responses:
-                        '200':
-                            description: Token JWT retourné
-                            content:
-                                application/json:
-                                    schema:
-                                        type: object
-                                        properties:
-                                            token:
-                                                type: string
-                        '401':
-                            description: Identifiants invalides
+                    security: []
+
+            /api/v1/utilisateur/login_check:
+                post:
+                    security: []
+
+            /api/v1/professionnel/login_check:
+                post:
+                    security: []
 
     areas:
         default:

--- a/laundrymap-back/config/packages/security.yaml
+++ b/laundrymap-back/config/packages/security.yaml
@@ -23,20 +23,9 @@ security:
             security: false
 
         public_api:
-            pattern: ^/api/v1/utilisateur/(login_check|inscription)|^/api/v1/professionnel/(login_check|inscription)|^/api/v1/auth/logout|^/api/doc
+            pattern: ^/api/v1/utilisateur/(login_check|inscription)|^/api/v1/professionnel/(login_check|inscription)|^/api/v1/auth/logout|^/api/v1/admin/login_check|^/api/doc
             stateless: true
             security: false
-
-        admin_login:
-            pattern: ^/api/v1/admin/login_check
-            stateless: true
-            provider: admin_provider
-            json_login:
-                check_path: /api/v1/admin/login_check
-                username_path: email
-                password_path: password
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
         # Routes admin protégées — provider Administrateur
         admin_api:

--- a/laundrymap-back/config/routes.yaml
+++ b/laundrymap-back/config/routes.yaml
@@ -4,19 +4,13 @@ controllers:
         namespace: App\Controller
     type: attribute
 
-app.swagger_ui:
-    path: /api/doc
-    methods: GET
-    defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+when@dev:
+    app.swagger_ui:
+        path: /api/doc
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
 
-api_login_check:
-    path: /api/login_check
-
-api_pro_login_check:
-    path: /api/v1/professionnel/login_check
-    methods: [POST]
-
-
-api_admin_login_check:
-    path: /api/v1/admin/login_check
-    methods: [POST]
+    app.swagger:
+        path: /api/doc.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger }

--- a/laundrymap-back/src/Controller/AdminAuthController.php
+++ b/laundrymap-back/src/Controller/AdminAuthController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\AdministrateurRepository;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/v1/admin')]
+final class AdminAuthController extends AbstractController
+{
+    public function __construct(
+        #[Autowire('%env(bool:COOKIE_SECURE)%')]
+        private readonly bool $cookieSecure,
+        #[Autowire('%kernel.environment%')]
+        private readonly string $appEnv,
+    ) {}
+
+    #[Route('/login_check', name: 'admin_login_check', methods: ['POST'])]
+    #[OA\Tag(name: 'Authentification Admin')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['email', 'password'],
+            properties: [
+                new OA\Property(property: 'email',    type: 'string', example: 'admin@example.com'),
+                new OA\Property(property: 'password', type: 'string', example: 'Admin1234.'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Connexion réussie — token JWT',
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'token', type: 'string', example: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9...'),
+                new OA\Property(property: 'email', type: 'string', example: 'admin@example.com'),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Identifiants invalides')]
+    public function loginCheck(
+        Request $request,
+        AdministrateurRepository $adminRepository,
+        UserPasswordHasherInterface $passwordHasher,
+        JWTTokenManagerInterface $jwtManager,
+    ): JsonResponse {
+        $body   = json_decode($request->getContent(), true);
+        $email  = $body['email']    ?? null;
+        $mdp    = $body['password'] ?? null;
+
+        if (!$email || !$mdp) {
+            return $this->json(['message' => 'Les champs email et password sont requis'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $admin = $adminRepository->findOneByEmail($email);
+
+        if (!$admin || !$passwordHasher->isPasswordValid($admin, $mdp)) {
+            return $this->json(['message' => 'Identifiants invalides'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $token = $jwtManager->create($admin);
+
+        $cookie = Cookie::create('BEARER')
+            ->withValue($token)
+            ->withExpires(time() + 3600)
+            ->withPath('/')
+            ->withDomain(null)
+            ->withSecure($this->cookieSecure)
+            ->withHttpOnly(true)
+            ->withSameSite('strict');
+
+        $data = ['email' => $admin->getEmail()];
+        if ($this->appEnv === 'dev') {
+            $data['token'] = $token;
+        }
+        $response = $this->json($data, Response::HTTP_OK);
+
+        $response->headers->setCookie($cookie);
+
+        return $response;
+    }
+}

--- a/laundrymap-back/src/Controller/ProfessionnelController.php
+++ b/laundrymap-back/src/Controller/ProfessionnelController.php
@@ -33,6 +33,8 @@ class ProfessionnelController extends AbstractController
     public function __construct(
         #[Autowire('%env(bool:COOKIE_SECURE)%')]
         private readonly bool $cookieSecure,
+        #[Autowire('%kernel.environment%')]
+        private readonly string $appEnv,
     ) {}
 
     /**
@@ -142,11 +144,15 @@ class ProfessionnelController extends AbstractController
                 ->withSecure($this->cookieSecure)
                 ->withHttpOnly(true)
                 ->withSameSite('strict');
-            $response = $this->json([
+            $data = [
                 'message' => 'Connexion réussie',
                 'email'   => $utilisateur->getEmail(),
                 'role'    => $utilisateur->getRolePro()[0],
-            ], Response::HTTP_OK);
+            ];
+            if ($this->appEnv === 'dev') {
+                $data['token'] = $token;
+            }
+            $response = $this->json($data, Response::HTTP_OK);
             $response->headers->setCookie($cookie);
             return $response;
         } catch (\Throwable $e) {

--- a/laundrymap-back/src/Controller/UtilisateurController.php
+++ b/laundrymap-back/src/Controller/UtilisateurController.php
@@ -30,6 +30,8 @@ final class UtilisateurController extends AbstractController
     public function __construct(
         #[Autowire('%env(bool:COOKIE_SECURE)%')]
         private readonly bool $cookieSecure,
+        #[Autowire('%kernel.environment%')]
+        private readonly string $appEnv,
     ) {}
 
     /**
@@ -137,11 +139,15 @@ final class UtilisateurController extends AbstractController
                 ->withSecure($this->cookieSecure)
                 ->withHttpOnly(true)
                 ->withSameSite('strict');
-            $response = $this->json([
+            $data = [
                 'message' => 'Connexion réussie',
                 'email'   => $utilisateur->getEmail(),
                 'role'    => $utilisateur->getRole()[0],
-            ], Response::HTTP_OK);
+            ];
+            if ($this->appEnv === 'dev') {
+                $data['token'] = $token;
+            }
+            $response = $this->json($data, Response::HTTP_OK);
             $response->headers->setCookie($cookie);
             return $response;
         } catch (\Throwable $e) {


### PR DESCRIPTION
Ajout de token en réponse json pour le swagger uniquement en dev afin de tester les endpoints 


  1. config/packages/security.yaml

  Suppression du firewall admin_login qui utilisait le mécanisme
  json_login natif de Symfony (délégation à Lexik JWT via
  success_handler). Ce firewall était le seul de ce type — user et pro
  avaient déjà leurs propres controllers custom.

  Ajout de /api/v1/admin/login_check dans public_api pour que la route
  soit accessible sans token, en cohérence avec user et pro.

  ---
  2. config/routes.yaml

  - Route Swagger (/api/doc et /api/doc.json) désormais uniquement en dev
  via when@dev — la documentation n'est plus exposée en production.
  - Suppression des routes déclarées manuellement (api_login_check,
  api_pro_login_check, api_admin_login_check) : elles sont maintenant
  toutes portées par les attributs #[Route] directement dans les
  controllers.

  ---
  3. config/packages/lexik_jwt_authentication.yaml

  Activation du authorization_header (enabled: false → true). Le JWT peut
  maintenant être transmis soit via le cookie HTTP-Only BEARER, soit via
  l'en-tête Authorization: Bearer <token> — nécessaire pour les appels
  depuis Swagger UI.

  ---
  4. config/packages/nelmio_api_doc.yaml
  - Route Swagger (/api/doc et /api/doc.json) désormais uniquement en dev via when@dev — la documentation n'est plus exposée en production.
  - Suppression des routes déclarées manuellement (api_login_check, api_pro_login_check, api_admin_login_check) : elles sont maintenant toutes portées par les attributs #[Route] directement
   dans les controllers.

  ---
  3. config/packages/lexik_jwt_authentication.yaml

  directement dans les controllers.

  ---
  3. config/packages/lexik_jwt_authentication.yaml

  Activation du authorization_header (enabled: false → true). Le JWT peut maintenant être transmis soit via le cookie HTTP-Only BEARER, soit via l'en-tête Authorization: Bearer <token>
   — nécessaire pour les appels depuis Swagger UI.

  ---
  4. config/packages/nelmio_api_doc.yaml

  Simplification de la documentation Swagger admin : suppression de la description manuelle en doublon de la route admin (request body, réponses, etc.) qui était déjà portée par les
  annotations #[OA\...] dans AdminAuthController.

  Ajout des surcharges security: [] sur les 3 routes login_check (admin, utilisateur, professionnel) pour que Swagger affiche ces routes sans cadenas — elles n'ont pas besoin d'un
  token pour être appelées.

  ---
  5. src/Controller/ProfessionnelController.php + UtilisateurController.php

  Injection de %kernel.environment% dans le constructeur via #[Autowire].

  Token JWT conditionnel dans le body JSON : le champ token n'est inclus dans la réponse JSON que si APP_ENV === 'dev'. En production, seul le cookie HTTP-Only BEARER transporte le
  token — ce qui évite tout risque de stockage côté client en clair.

  ---
  6. laundrymap-back/.env

  Ajout de 3 variables de configuration pour le système de signalement anti-abus (règles RG-209 et RG-210) :
  - SIGNALEMENT_SEUIL_MASQUAGE — nombre de signalements déclenchant le masquage automatique d'un commentaire
  - SIGNALEMENT_LIMITE_UTILISATEUR — quota max de signalements par utilisateur sur une période
  - SIGNALEMENT_PERIODE_HEURES — durée de la fenêtre de rate limiting

  ---
