### PR TITLE
fix 500 fiche laverie : suppression dépendances inutiles dans SendEma…

### DIFF
--- a/laundrymap-back/.env
+++ b/laundrymap-back/.env
@@ -72,10 +72,14 @@ FRONTEND_PUBLIC_DIR=/frontend-public
 ###< fichiers publics frontend ###
 
 ###> signalement anti-abus ###
-# Nombre de signalements avant masquage automatique du commentaire (RG-209)
+# Seuil de signalements à partir duquel le commentaire est masqué du public (RG-209)
+# Le masquage est calculé dynamiquement : modifier cette valeur prend effet immédiatement
 SIGNALEMENT_SEUIL_MASQUAGE=5
 # Nombre max de signalements qu'un utilisateur peut envoyer sur la période (RG-210)
 SIGNALEMENT_LIMITE_UTILISATEUR=10
 # Durée de la période en heures pour le rate limiting (RG-210)
 SIGNALEMENT_PERIODE_HEURES=24
+# Total de signalements cumulés sur les commentaires d'un utilisateur avant qu'il
+# n'apparaisse comme à examiner pour bannissement dans la modération utilisateurs (RG-211)
+SIGNALEMENT_SEUIL_BANNISSEMENT=15
 ###< signalement anti-abus ###

--- a/laundrymap-back/src/Controller/FicheLaverieController.php
+++ b/laundrymap-back/src/Controller/FicheLaverieController.php
@@ -60,10 +60,10 @@ class FicheLaverieController extends AbstractController
 
         //  Images du carousel (LaverieMedia → Media)
         $laverieMedias = $this->laverieMediaRepository->findBy(['laverie' => $laverie]);
-        $images = array_values(array_map(
-            fn($lm) => $lm->getMedia()->getEmplacement(),
+        $images = array_values(array_filter(array_map(
+            fn($lm) => $lm->getMedia()?->getEmplacement(),
             $laverieMedias
-        ));
+        )));
 
 
         $adresse = $laverie->getAdresse();

--- a/laundrymap-back/src/Service/SendEmailService.php
+++ b/laundrymap-back/src/Service/SendEmailService.php
@@ -4,17 +4,12 @@ namespace App\Service;
 
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
-use App\Entity\Utilisateur;
 use Twig\Environment;
 
 class SendEmailService
 {
     public function __construct(
         private MailerInterface $mailer,
-        private UrlGeneratorInterface $urlGenerator,
-        private JWTTokenManagerInterface $jwtManager,
         private Environment $twig
     ) {}
 


### PR DESCRIPTION
…ilService

SendEmailService injectait JWTTokenManagerInterface et UrlGeneratorInterface sans jamais les utiliser, ce qui pouvait bloquer l'autowiring de FicheLaverieController en prod depuis l'ajout de ce service dans bed1ff3.

- Supprime JWTTokenManagerInterface, UrlGeneratorInterface et l'import Utilisateur de SendEmailService (dead code)
- Ajoute null-safe ?->getEmplacement() + array_filter sur les médias de FicheLaverieController pour éviter TypeError si Media orphelin
- Commite SIGNALEMENT_SEUIL_BANNISSEMENT=15 dans .env (manquait en prod, causait 500 sur toutes les routes signalement)